### PR TITLE
Expose an option to use Gpu Device ID

### DIFF
--- a/Plugins/AzureKinectUnreal/Source/AzureKinectUnreal/Private/AzureKinectDevice.cpp
+++ b/Plugins/AzureKinectUnreal/Source/AzureKinectUnreal/Private/AzureKinectDevice.cpp
@@ -30,10 +30,15 @@ AzureKinectDevice::~AzureKinectDevice()
 	Shutdown();
 }
 
-bool AzureKinectDevice::Initialize(k4a_depth_mode_t DepthMode)
+bool AzureKinectDevice::Initialize(k4a_depth_mode_t DepthMode, int32_t GpuDeviceId)
 {
 	try
 	{
+		k4abt_tracker_t tracker = nullptr;
+		k4abt_tracker_configuration_t tracker_config = K4ABT_TRACKER_CONFIG_DEFAULT;
+		tracker_config.processing_mode = K4ABT_TRACKER_PROCESSING_MODE_GPU;
+		tracker_config.gpu_device_id = GpuDeviceId;
+
 		// Open the Azure Kinect Device
 		NativeKinectDevice = k4a::device::open(DeviceId);
 
@@ -48,7 +53,7 @@ bool AzureKinectDevice::Initialize(k4a_depth_mode_t DepthMode)
 		k4a::calibration sensorCalibration = NativeKinectDevice.get_calibration(deviceConfig.depth_mode, deviceConfig.color_resolution);
 
 		// Create the Body tracker using the calibration
-		NativeBodyTracker = k4abt::tracker::create(sensorCalibration);
+		NativeBodyTracker = k4abt::tracker::create(sensorCalibration, tracker_config);
 	}
 	catch (k4a::error initError)
 	{

--- a/Plugins/AzureKinectUnreal/Source/AzureKinectUnreal/Private/AzureKinectDevice.cpp
+++ b/Plugins/AzureKinectUnreal/Source/AzureKinectUnreal/Private/AzureKinectDevice.cpp
@@ -34,7 +34,6 @@ bool AzureKinectDevice::Initialize(k4a_depth_mode_t DepthMode, int32_t GpuDevice
 {
 	try
 	{
-		k4abt_tracker_t tracker = nullptr;
 		k4abt_tracker_configuration_t tracker_config = K4ABT_TRACKER_CONFIG_DEFAULT;
 		tracker_config.processing_mode = K4ABT_TRACKER_PROCESSING_MODE_GPU;
 		tracker_config.gpu_device_id = GpuDeviceId;

--- a/Plugins/AzureKinectUnreal/Source/AzureKinectUnreal/Private/AzureKinectManager.cpp
+++ b/Plugins/AzureKinectUnreal/Source/AzureKinectUnreal/Private/AzureKinectManager.cpp
@@ -19,7 +19,7 @@ UAzureKinectManager::~UAzureKinectManager()
 	Instance = nullptr;
 }
 
-void UAzureKinectManager::InitDevice(int32 DeviceId, EKinectDepthMode DepthMode, int32 TimeOutInMilliSecs)
+void UAzureKinectManager::InitDevice(int32 DeviceId, EKinectDepthMode DepthMode, int32 TimeOutInMilliSecs, int32 GpuDeviceId)
 {
 	if (!Instance)
 	{
@@ -40,8 +40,7 @@ void UAzureKinectManager::InitDevice(int32 DeviceId, EKinectDepthMode DepthMode,
 	}
 
 	AzureKinectDevice *KinectDevice = new AzureKinectDevice(DeviceId, TimeOutInMilliSecs);
-	bool bIsInitialized = KinectDevice->Initialize((k4a_depth_mode_t)DepthMode);
-
+	bool bIsInitialized = KinectDevice->Initialize((k4a_depth_mode_t)DepthMode, GpuDeviceId);
 	if (bIsInitialized)
 	{
 		Instance->KinectDevicesById.Add(DeviceId, KinectDevice);

--- a/Plugins/AzureKinectUnreal/Source/AzureKinectUnreal/Public/AzureKinectDevice.h
+++ b/Plugins/AzureKinectUnreal/Source/AzureKinectUnreal/Public/AzureKinectDevice.h
@@ -26,7 +26,7 @@ public:
 	~AzureKinectDevice();
 
 	/** Initalizes the Azure kinect device with the given Depth Mode. */
-	bool Initialize(k4a_depth_mode_t DepthMode);
+	bool Initialize(k4a_depth_mode_t DepthMode, int32_t GpuDeviceId);
 	/** Shuts down this device */
 	void Shutdown();
 

--- a/Plugins/AzureKinectUnreal/Source/AzureKinectUnreal/Public/AzureKinectManager.h
+++ b/Plugins/AzureKinectUnreal/Source/AzureKinectUnreal/Public/AzureKinectManager.h
@@ -32,9 +32,10 @@ public:
 	 * @param DeviceId The device id of the Azure Kinect Device to initialize.
 	 * @param DepthMode The default is set to NFOV_UNBINNED. For body tracking it should be NFOV_UNBINNED or WFOV_BINNED.
 	 * @param TimeOutInMilliSecs Default is Zero (Non-blocking). Set it to -1 (K4A_WAIT_INFINITE) for Blocking call.
+	 * @param GpuDeviceId Gpu device Id to use.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Azure Kinect", meta = (DisplayName = "Init Azure Kinect"))
-	static void InitDevice(int32 DeviceId = 0, EKinectDepthMode DepthMode = EKinectDepthMode::NFOV_UNBINNED, int32 TimeOutInMilliSecs = 0);
+	static void InitDevice(int32 DeviceId = 0, EKinectDepthMode DepthMode = EKinectDepthMode::NFOV_UNBINNED, int32 TimeOutInMilliSecs = 0, int32 GpuDeviceId = 0);
 
 	/** Shuts down the azure kinect device with the given device id. */
 	UFUNCTION(BlueprintCallable, Category = "Azure Kinect", meta = (DisplayName = "Shutdown Azure Kinect"))


### PR DESCRIPTION
Exposes the Gpu Device ID to the AzureKinect Manager - This is useful when you want control over what GPU the kinect will use. Also, this is a solution for RTX 30xx cards not working - if you have 2 graphics adapters available.

- [x ] My contribution is fully done and ready to be merged as is.
- [x] My pull request description contains the entire list of fixes, additions, or removals.
- [x ] I have commented my code to the point that other devs can pick it up.

## Summary
<!-- A brief few sentences summarizing the changes in the pull request -->
Exposed an int32 specifying the GpuDeviceID that can be used to control what GPU the kinect should use.

### Added
 - <!-- Only newly added things should be mentioned here-->
The GpuDeviceID int32 is exposed both to AzureKinectDevice::Initialize and UAzureKinectManager::InitDevice.
Furthermore a tracker_config is setup containing the settings and passed on to k4abt::tracker::create(..) in AzureKinectDevice.cpp

### Removed
 - <!-- Removals here -->

### Updated
 - <!-- Any other modifications or version increases of depdencencies here -->
